### PR TITLE
Added Redis Integration for ETH Data Streaming

### DIFF
--- a/data_fetch/redis_client.py
+++ b/data_fetch/redis_client.py
@@ -1,0 +1,17 @@
+import redis
+import json
+
+# Connect to Redis
+r = redis.Redis(host="localhost", port=6379, db=0)
+
+# Subscribe to the channel
+p = r.pubsub()
+p.subscribe("eth_data")
+
+print("Waiting for data...")
+
+# Listen for new messages
+for message in p.listen():
+    if message["type"] == "message":
+        data = json.loads(message["data"])
+        print("Received:", data['best_ask'])

--- a/data_fetch/redis_server.py
+++ b/data_fetch/redis_server.py
@@ -1,0 +1,34 @@
+import asyncio
+import ccxt.pro as ccxt
+import redis
+import json
+
+# Connect to Redis
+r = redis.Redis(host="localhost", port=6379, db=0)
+
+async def fetch_order_book():
+    exchange = ccxt.binance()  # Initialize Exchange
+    
+    try:
+        await exchange.load_markets()
+        symbol = "ETH/USDT"
+
+        while True:
+             order_book = await exchange.watch_order_book(symbol)
+             message = {
+                "symbol": symbol,
+                "best_ask": order_book['asks'][0],
+                "best_bid": order_book['bids'][0],
+                "timestamp": order_book['timestamp']
+            }
+             r.publish("eth_data", json.dumps(message))
+             print("Published:", message)
+        
+    except Exception as e:
+        print("Error:", e)
+
+    finally:
+        await exchange.close()  # Ensure WebSocket is closed properly
+
+# Run event loop
+asyncio.run(fetch_order_book())


### PR DESCRIPTION
🔹 Summary:
This PR integrates Redis Pub/Sub with CCXT Pro WebSocket to stream ETH/USDT order book data from Binance.


🔹 Changes Made:
Implemented WebSocket Data Fetching

Connected to Binance WebSocket using ccxt.pro.
Fetched order book data (best_ask, best_bid, timestamp).
Integrated Redis for Real-Time Streaming

Published ETH order book updates to Redis on the eth_data channel.
Subscribed to the channel and printed received messages.
Handled Edge Cases

Ensured WebSocket connection closes properly (await exchange.close()).
Wrapped logic in a try-except block for better error handling.
🔹 How It Works:
Producer (WebSocket to Redis): Fetches ETH/USDT order book and pushes updates to Redis.
Consumer (Redis Subscriber): Listens for updates and prints them.
🔹 Next Steps:
Extend to support multiple symbols.
Add structured logging instead of print().
Optimize reconnection handling if WebSocket disconnects.
